### PR TITLE
Added the option to flush immediately

### DIFF
--- a/lib/librato-sidekiq/middleware.rb
+++ b/lib/librato-sidekiq/middleware.rb
@@ -5,7 +5,7 @@ module Librato
         true
       end
 
-      cattr_accessor :whitelist_queues, :blacklist_queues, :whitelist_classes, :blacklist_classes do
+      cattr_accessor :whitelist_queues, :blacklist_queues, :whitelist_classes, :blacklist_classes, :flush_immediately do
         []
       end
 
@@ -24,7 +24,8 @@ module Librato
           :whitelist_queues => self.whitelist_queues, 
           :blacklist_queues => self.blacklist_queues, 
           :whitelist_classes => self.whitelist_classes, 
-          :blacklist_classes => self.blacklist_classes
+          :blacklist_classes => self.blacklist_classes,
+          :flush_immediately => self.flush_immediately
         }
       end
 
@@ -81,6 +82,7 @@ module Librato
             end
           end
         end
+        Librato.tracker.flush if self.flush_immediately
       end
     end
   end


### PR DESCRIPTION
We tried using this gem, but would not get any updates to Librato for sidekiq related metrics. We played around with it for a while, and the only thing we found that helped was manually forcing a flush at the end of the middleware after the librato calls. I see that librato has a flush interval, and I wasn't able to select a value for that that resulted in sidekiq sending the metrics to librato. I wouldn't want that number to be low anyway, since I want to use the librato-rails instrumentation throughout the app without slowing things down.

In case it helps at all, I'm using sidekiq 2.11.2, sidekiq-pro 1.0.0, ruby 1.9.3, rails 3.2.12, librato-metrics 1.1.1, and librato-rails 0.10.0.

I implemented this as an option so that it won't change the default behavior of the middleware. If you observe that this is a permanent bug caused by some newer version of something, you may want to default it to true.
