### PR TITLE
Only add/remove to chain when options change

### DIFF
--- a/lib/librato-sidekiq/client_middleware.rb
+++ b/lib/librato-sidekiq/client_middleware.rb
@@ -1,12 +1,12 @@
 module Librato
   module Sidekiq
     class ClientMiddleware < Middleware
-      def reconfigure
+      def self.reconfigure
         # puts "Reconfiguring with: #{options}"
         ::Sidekiq.configure_client do |config|
           config.client_middleware do |chain|
-            chain.remove self.class
-            chain.add self.class, options
+            chain.remove self
+            chain.add self, options
           end
         end
       end

--- a/spec/unit/client_middleware_spec.rb
+++ b/spec/unit/client_middleware_spec.rb
@@ -13,19 +13,26 @@ describe Librato::Sidekiq::ClientMiddleware do
     Librato::Sidekiq::ClientMiddleware.new
   end
 
-  describe '#intialize' do
-    it 'should call reconfigure' do
-      expect(Sidekiq).to receive(:configure_client)
+  describe '#initialize' do
+    it 'should not call reconfigure' do
+      expect(Sidekiq).not_to receive(:configure_client)
       Librato::Sidekiq::ClientMiddleware.new
     end
   end
 
   describe '#configure' do
 
-    before(:each) { Sidekiq.should_receive(:configure_client) }
+    before(:each) do
+      allow(described_class).to receive(:reconfigure)
+    end
 
     it 'should yield with it self as argument' do
       expect { |b| Librato::Sidekiq::ClientMiddleware.configure &b }.to yield_with_args(Librato::Sidekiq::ClientMiddleware)
+    end
+
+    it 'should call reconfigure' do
+      expect(described_class).to receive(:reconfigure)
+      described_class.configure
     end
 
     it 'should return a new instance' do
@@ -34,19 +41,20 @@ describe Librato::Sidekiq::ClientMiddleware do
 
   end
 
-  describe '#reconfigure' do
+  describe '.reconfigure' do
 
     let(:chain) { double() }
     let(:config) { double() }
 
     it 'should add itself to the server middleware chain' do
       expect(chain).to receive(:remove).with Librato::Sidekiq::ClientMiddleware
-      expect(chain).to receive(:add).with Librato::Sidekiq::ClientMiddleware, middleware.options
+      expect(chain).to receive(:add).with Librato::Sidekiq::ClientMiddleware,
+                                          described_class.options
 
       expect(config).to receive(:client_middleware).once.and_yield(chain)
       expect(Sidekiq).to receive(:configure_client).once.and_yield(config)
 
-      middleware.reconfigure
+      described_class.reconfigure
     end
   end
 


### PR DESCRIPTION
There's no reason to add/remove the middleware from the middleware chain every time a sidekiq job runs. Only do it when the options change.

Fixes #7
