### PR TITLE
Blacklisted queues should not send general metrics

### DIFF
--- a/lib/librato-sidekiq/middleware.rb
+++ b/lib/librato-sidekiq/middleware.rb
@@ -60,7 +60,7 @@ module Librato
         result = yield
         elapsed = (Time.now - start_time).to_f
 
-        return result unless enabled
+        return result unless enabled && allowed_to_submit(queue, worker_instance)
         # puts "#{worker_instance} #{queue}"
 
         stats = ::Sidekiq::Stats.new
@@ -76,7 +76,6 @@ module Librato
 
       def track(tracking_group, stats, worker_instance, msg, queue, elapsed)
         submit_general_stats tracking_group, stats
-        return unless allowed_to_submit queue, worker_instance
         # puts "doing Librato insert"
         tracking_group.group queue.to_s do |q|
           q.increment 'processed'

--- a/spec/unit/client_middleware_spec.rb
+++ b/spec/unit/client_middleware_spec.rb
@@ -87,11 +87,8 @@ describe Librato::Sidekiq::ClientMiddleware do
         middleware.blacklist_queues << queue_name
       end
 
-      it { expect { |b| middleware.call(some_worker_instance, some_message, queue_name, &b) }.to yield_with_no_args }
-
-      it 'should measure increment queued metric' do
-        expect(meter).to receive(:increment).with 'queued'
-        middleware.call(some_worker_instance, some_message, queue_name) {}
+      it 'should not send any metrics' do
+        Librato.should_not_receive(:group)
       end
 
     end

--- a/spec/unit/middleware_spec.rb
+++ b/spec/unit/middleware_spec.rb
@@ -87,20 +87,8 @@ describe Librato::Sidekiq::Middleware do
         middleware.blacklist_queues << queue_name
       end
 
-      it { expect { |b| middleware.call(some_worker_instance, some_message, queue_name, &b) }.to yield_with_no_args }
-
-      it 'should measure increment processed metric' do
-        expect(meter).to receive(:increment).with "processed"
-        middleware.call(some_worker_instance, some_message, queue_name) {}
-      end
-
-      it 'should measure general metrics' do
-        {"enqueued" => 1, "failed" => 2, "scheduled" => 3 }.each do |method, stat|
-          expect(meter).to receive(:measure).with(method.to_s, stat)
-        end
-        expect(meter).to receive(:increment).with "processed"
-
-        middleware.call(some_worker_instance, some_message, queue_name) {}
+      it 'should not send any metrics' do
+        Librato.should_not_receive(:group)
       end
 
     end


### PR DESCRIPTION
We ran into an issue where some of our queues tend to spin up a large number of small/fast jobs, and the overhead associated with the metrics middleware was causing a substantial slowdown in clearing those queues, even when the queue in question was blacklisted. Digging in, I noticed that blacklisting a queue doesn't completely prevent metrics from being reported - it just short-circuits the detailed reporting, but still triggers the general stats. This PR changes that behavior so that nothing will get reported when the middleware is processing a blacklisted queue.
